### PR TITLE
Retract existing singular attr value based on data, not delta

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -60,7 +60,30 @@ Every entity stored in Asami must have the property `:id <ident>`. Entities crea
 
 See a complete usage example in https://github.com/fulcrologic/fulcro-rad-demo .
 
-TIP: It is better to call `asami.core/shutdown` when shutting down the backend to ensure that the database files are not unnecessarily large. (They are created with more space so that data can be inserted quickly and shutdown trims them to the actual content.)
+TIP: It is better to call `asami.core/shutdown` when shutting down the backend to ensure that the database files are not unnecessarily large. Though you can likely simply rely on the JVM shutdown hook calling this, which Asami itself registers. (They are created with more space so that data can be inserted quickly and shutdown trims them to the actual content.)
+(Beware: as of Asami 2.3.2, when you call `shutdown`, it will close files but not reset the internal `connections` map and subsequent `asami/start-connections` will not re-initialize them properly. So avoid calling shutdown repeatedly during REPLing.)
+
+=== Troubleshooting
+
+==== Enable debug logging
+
+You can enable debug logging for the adapter. With fulcro-rad-demo or fulcro-template you can configure this in e.g. its `dev.edn`:
+
+```diff
+- {:taoensso.timbre/logging-config {:min-level :info}}
++ {:taoensso.timbre/logging-config {:min-level [[#{"cz.holyjak.rad.database-adapters.asami.*"} :debug]
++                                               [#{"*"} :info]]}}
+
+```
+
+==== Exploring the data
+
+Fetch all the entity-attribute-value triples from the database:
+
+```clojure
+(d/q [:find '?e '?a '?v :where '[?e ?a ?v]]
+       (d/db (:production asami-connections)))
+```
 
 == More info
 
@@ -68,13 +91,17 @@ TIP: It is better to call `asami.core/shutdown` when shutting down the backend t
 
 The order of multi-valued attributes is lost (Asami returns them as sets, which we turn into a vector).
 
-As of Asami 2.3.2 you cannot create an entity and _refer_ to the entity from another one in the same transaction when using the entity form of `tx-data`. If the entity and reference are both created using the quadruplets form (`[:db/add <entity> <attr> <val>`) https://github.com/quoll/asami/pull/2[then this works].
+As of Asami 2.3.2 you cannot create an entity and _refer_ to the entity from another one in the same transaction when using the _entity form_ of `tx-data`. If the entity and reference are both created using the quadruplets form (`[:db/add <entity> <attr> <val>`) https://github.com/quoll/asami/pull/2[then this works].
 
 === Implementation details
 
 We assoc to each persistent entity `:id <ident>` (see link:++https://github.com/quoll/asami/wiki/4.-Transactions#identity-values++[Asami's Identity Values]) so that we can easily refer to it in statements and from other entities. This is then used as a _lookup ref_ in insert/update statements and in `:ref` attributes of other properties. (`:ref` attributes stored via a form are automatically translated into this form.) However this property is dissoc-ed when reading. (We could likely also use `:db/ident` instead though this has not been tested.)
 
 We store the full ident in the `:id` because we cannot be sure that the ID values are globally unique though we know that Fulcro would break if they were not unique for the given entity. (Actually they should be globally unique, being UUIDs, but we might want to support other kinds of IDs in the future that do not guarantee this. We could store the full ident only on such attributes - and maybe we will.)
+
+=== Design decisions
+
+**Quadruples over entities** We translate each Fulcro entity diff into a series of quadruplet assertions and retractions and transact these. The reason for this is that we might want to transact multiple new entities that refer to each other in a single transaction (think of saving a form with a subform). I am not sure Asami tempids work for this and in any case they are not ideal because, in the face of no schema, they are just negative integers and then even regular attribute value that happen to be negative integers matching one of the tempids would be replaced with a reference. Instead, we use lookup ids such as `{:id [:entity/id #uuid "some-value"]}` but these require that the entity already exists, when used in the entity form, while quadruplets manage to create a new entity and resolve references to it (see https://github.com/quoll/asami/pull/2). One of the disadvantages is that we cannot use the `attribute'` or `attribute+` shorthand forms.
 
 == Limitations
 

--- a/README.adoc
+++ b/README.adoc
@@ -120,3 +120,20 @@ Limitations and features that are not supported:
 Not tested:
 
 * Multiple databases / schemas
+
+== Development
+
+=== Testing
+
+Run tests: `clj -M:test:run-tests`
+
+Also see the `(comment ..)` at the bottom of most `-spec` tests for running those in the REPL.
+
+.Focusing a test
+====
+```clojure
+(specification "descr." :focus ...)
+```
+====
+
+then run `(fulcro-spec.reporters.repl/run-tests (comp :focus meta))`

--- a/README.adoc
+++ b/README.adoc
@@ -63,6 +63,12 @@ See a complete usage example in https://github.com/fulcrologic/fulcro-rad-demo .
 TIP: It is better to call `asami.core/shutdown` when shutting down the backend to ensure that the database files are not unnecessarily large. Though you can likely simply rely on the JVM shutdown hook calling this, which Asami itself registers. (They are created with more space so that data can be inserted quickly and shutdown trims them to the actual content.)
 (Beware: as of Asami 2.3.2, when you call `shutdown`, it will close files but not reset the internal `connections` map and subsequent `asami/start-connections` will not re-initialize them properly. So avoid calling shutdown repeatedly during REPLing.)
 
+=== Tips
+
+==== Lookup refs
+
+When inserting data manually, remember to set `:id <ident>`. You can then use it as a lookup ref, e.g. in add: `[:db/add [:id <ident>] <prop> <val>]`.
+
 === Troubleshooting
 
 ==== Enable debug logging

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {;:paths   ["src/shared" "src/asami"]
 
  :deps    {org.clojars.quoll/asami {:mvn/version "2.3.2"}
-           com.fulcrologic/fulcro-rad             {:mvn/version "1.2.7"}
+           com.fulcrologic/fulcro-rad             {:mvn/version "1.4.0"} ; Note: We need Fulcro 3.5.3+ so default vals etc have correct diffs
            com.wsscode/pathom                     {:mvn/version "2.4.0"}
            edn-query-language/eql                 {:mvn/version "1.0.1"}
            com.taoensso/encore                    {:mvn/version "3.1.0"}

--- a/src/cz/holyjak/rad/database_adapters/asami/connect.cljc
+++ b/src/cz/holyjak/rad/database_adapters/asami/connect.cljc
@@ -7,6 +7,7 @@
     [taoensso.timbre :as log]))
 
 (defn config->url [{:asami/keys [driver] :as config}]
+  {:pre [config]}
   (assert driver (str "The provided `config` lacks the required key `:asami/driver`. Actual keys: " (keys config)))
   (case driver
     :mem (str "asami:mem://" (:asami/database config))
@@ -34,8 +35,33 @@
   ;(set! *data-readers* graph/node-reader)
   (d/create-database (config->url {:asami/driver :local, :asami/database "playground3"}))
   @(def conn (start-connections {aso/databases {:main {:asami/driver :local, :asami/database "playground3"}}}))
-  @(def conn (start-connections {aso/databases {:main {:asami/driver :mem, :asami/database "fulcro-rad-demo"}}}))
+  @(def conn (start-connections {aso/databases {:main {:asami/driver :mem, :asami/database "test123"}}}))
   (def dbm (:main conn))
+
+  (def graph (d/graph (d/db dbm)))
+  ; TO DO: transact `tx3` below
+  (def node-id (ffirst (graph/resolve-triple graph '?n :id [:order/id 2]))) ; => :a/node-27481
+
+  (d/q cz.holyjak.rad.database-adapters.asami.util/q-ident->node-id
+       (d/db dbm)
+       [:order/id 2])
+
+  (d/entity (d/db dbm) node-id)
+  (asami.entities.writer/entity-update->triples
+    graph
+    node-id
+    {:id [:order/id 2]
+     :order/descr "updated"})
+
+  ;; WIP: Ensure singular attributes by removing existing values
+  ;; WIP Get all [k v] pairs for the given node-id (refs are just node ids)
+  ; (asami.entities.reader/property-values graph node-id) ; all current props; calls ± resolve-triple
+  (graph/resolve-triple graph node-id :order/descr '?xval) ; -> (["Order ABC"])
+  (d/q '[:find ?xval :where [?e :order/descr ?xval] :in $ ?e] (d/db dbm) node-id)
+
+
+  (#'asami.core/as-graph dbm)
+  (satisfies? asami.graph/Graph dbm)
 
   (d/delete-database "asami:mem://test123")
   (d/create-database "asami:mem://test123")
@@ -44,11 +70,6 @@
     @(d/transact conn {:tx-data [{:id [:person/id "person2"]}
                                  [:db/add [:id [:person/id "person2"]] :person/full-name "Bob"]]})
     :tx-data)
-  ;; FIXME: The :db/add does NOT resolve `[:id ...]`. Relevant:
-  ;; you try to reference it with:
-  ;[:id [:cz.holyjak.rad.test-schema.address/id #uuid "ffffffff-ffff-ffff-ffff-000000000001"]]
-  ;That tells the transactor to look up a node that has that as an id. But... there IS no node that has that as an ID.
-  ; You're still creating it, so it doesn't exist yet. It won't exist until the end of the transaction
 
   (let [conn ...]
     @(d/transact conn {:tx-data [{:db/id -1 :id [:duplicate-test/id :SAME]}]})

--- a/src/cz/holyjak/rad/database_adapters/asami/connect.cljc
+++ b/src/cz/holyjak/rad/database_adapters/asami/connect.cljc
@@ -39,26 +39,8 @@
   (def dbm (:main conn))
 
   (def graph (d/graph (d/db dbm)))
-  ; TO DO: transact `tx3` below
+
   (def node-id (ffirst (graph/resolve-triple graph '?n :id [:order/id 2]))) ; => :a/node-27481
-
-  (d/q cz.holyjak.rad.database-adapters.asami.util/q-ident->node-id
-       (d/db dbm)
-       [:order/id 2])
-
-  (d/entity (d/db dbm) node-id)
-  (asami.entities.writer/entity-update->triples
-    graph
-    node-id
-    {:id [:order/id 2]
-     :order/descr "updated"})
-
-  ;; WIP: Ensure singular attributes by removing existing values
-  ;; WIP Get all [k v] pairs for the given node-id (refs are just node ids)
-  ; (asami.entities.reader/property-values graph node-id) ; all current props; calls ± resolve-triple
-  (graph/resolve-triple graph node-id :order/descr '?xval) ; -> (["Order ABC"])
-  (d/q '[:find ?xval :where [?e :order/descr ?xval] :in $ ?e] (d/db dbm) node-id)
-
 
   (#'asami.core/as-graph dbm)
   (satisfies? asami.graph/Graph dbm)

--- a/src/cz/holyjak/rad/database_adapters/asami/read.cljc
+++ b/src/cz/holyjak/rad/database_adapters/asami/read.cljc
@@ -1,4 +1,5 @@
 (ns cz.holyjak.rad.database-adapters.asami.read
+  "Support for reading RAD entities from Asami"
   (:require
     [clojure.spec.alpha :as s]
     [com.fulcrologic.guardrails.core :refer [>def >defn =>]]

--- a/src/cz/holyjak/rad/database_adapters/asami/util.cljc
+++ b/src/cz/holyjak/rad/database_adapters/asami/util.cljc
@@ -1,4 +1,5 @@
 (ns cz.holyjak.rad.database-adapters.asami.util
+  "INTERNAL NS. Subject to change without warning."
   (:require
     [com.fulcrologic.rad.attributes :as attr]))
 
@@ -28,3 +29,8 @@
   (if many?
     (map f v)
     (f v)))
+
+(def q-ident->node-id
+  "Query turning an ident into Asami node id
+  Usage: `(d/q q-ident->node-id db [:person/id #uuid \"...\")`"
+  '[:find ?e . :where [?e :id ?ident] :in $ ?ident])

--- a/src/cz/holyjak/rad/database_adapters/asami/util.cljc
+++ b/src/cz/holyjak/rad/database_adapters/asami/util.cljc
@@ -1,6 +1,7 @@
 (ns cz.holyjak.rad.database-adapters.asami.util
   "INTERNAL NS. Subject to change without warning."
   (:require
+    [asami.core :as d]
     [com.fulcrologic.rad.attributes :as attr]))
 
 (defn ensure!
@@ -34,3 +35,6 @@
   "Query turning an ident into Asami node id
   Usage: `(d/q q-ident->node-id db [:person/id #uuid \"...\")`"
   '[:find ?e . :where [?e :id ?ident] :in $ ?ident])
+
+(defn ident->node-id [db ident]
+  (d/q q-ident->node-id db ident))

--- a/src/cz/holyjak/rad/database_adapters/asami/write.cljc
+++ b/src/cz/holyjak/rad/database_adapters/asami/write.cljc
@@ -202,5 +202,5 @@
   [{::attr/keys [key->attribute] :as env} db schema delta]
   (let [retractions (->> (delta->singular-attrs-to-clear key->attribute schema delta)
                          (clear-singular-attributes-txn db))
-        change-txn  (delta->txn env schema delta)]
-    (concat retractions change-txn)))
+        changes  (delta->txn env schema delta)]
+    (update changes :txn concat retractions)))

--- a/test/cz/holyjak/rad/database_adapters/asami/read_spec.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami/read_spec.clj
@@ -9,8 +9,7 @@
     [cz.holyjak.rad.database-adapters.asami.read :as common]
     [fulcro-spec.core :refer [specification assertions]]
     [clojure.test :refer [use-fixtures]]
-    [com.fulcrologic.fulcro.algorithms.tempid :as tempid]
-    [asami.graph :as graph]))
+    [com.fulcrologic.fulcro.algorithms.tempid :as tempid]))
 
 (def all-attributes (vec (concat person/attributes address/attributes thing/attributes)))
 (def key->attribute (into {}

--- a/test/cz/holyjak/rad/database_adapters/asami/write_spec.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami/write_spec.clj
@@ -123,38 +123,43 @@
     (assertions
       "ID excluded, despite being singular"
       (write/delta->singular-attrs-to-clear
-        key->attribute
+        key->attribute :production
         {[::person/id pid] {::person/id pid}})
       => nil
       "Updated singular attribute is to be cleared"
       (write/delta->singular-attrs-to-clear
-        key->attribute
+        key->attribute :production
         {[::person/id pid] {::person/id pid, ::person/full-name {:before "Jo" :after "June"}}})
       => {[::person/id pid] #{::person/full-name}}
       "Removed singular attribute is to be cleared (RAD would remove it too but let's not rely on it having latest value)"
       (write/delta->singular-attrs-to-clear
-        key->attribute
+        key->attribute :production
         {[::person/id pid] {::person/id pid, ::person/full-name {:before "Jo" :after nil}}})
       => {[::person/id pid] #{::person/full-name}}
       "New entity is ignored, no matter its singular attrs"
       (write/delta->singular-attrs-to-clear
-        key->attribute
+        key->attribute :production
         {[::person/id tempid] {::person/id tempid, ::person/full-name {:after "June"}}})
       => nil
       "Newly set singular attribute on existing entity is to be cleared (for I don't want to trust Fulcro's :before 100%)"
       (write/delta->singular-attrs-to-clear
-        key->attribute
+        key->attribute :production
         {[::person/id pid] {::person/id tempid, ::person/email {:after "new@ma.il"}}})
       => {[::person/id pid] #{::person/email}}
       "Non-singular attrs are ignored"
       (write/delta->singular-attrs-to-clear
-        key->attribute
+        key->attribute :production
         {[::person/id pid] {::person/addresses {:before [[::address/id id1]]
                                                 :after  [[::address/id id1], [::address/id id2]]}}})
       => nil
+      "Attributes from a different schema are ignored"
+      (write/delta->singular-attrs-to-clear
+        key->attribute :another-schema
+        {[::person/id pid] {::person/id pid, ::person/full-name {:before "Jo" :after "June"}}})
+      => nil
       "All singular attrs are included"
       (write/delta->singular-attrs-to-clear
-        key->attribute
+        key->attribute :production
         {[::person/id pid] {::person/id pid,
                             ::person/email           {:after "new@ma.il"}
                             ::person/full-name       {:before "Jo" :after "June"}
@@ -164,7 +169,7 @@
       => {[::person/id pid] #{::person/email ::person/full-name ::person/primary-address ::person/role}}
       "All updated entities are included"
       (write/delta->singular-attrs-to-clear
-        key->attribute
+        key->attribute :production
         {[::person/id pid]  {::person/id              pid,
                              ::person/email           {:after "new@ma.il"}
                              ::person/full-name       {:before "Jo" :after "June"}

--- a/test/cz/holyjak/rad/database_adapters/asami/write_spec.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami/write_spec.clj
@@ -1,0 +1,79 @@
+(ns cz.holyjak.rad.database-adapters.asami.write-spec
+  (:require
+    [asami.core :as d]
+    [cz.holyjak.rad.database-adapters.asami :as asami]
+    [cz.holyjak.rad.database-adapters.asami-options :as aso]
+    [cz.holyjak.rad.database-adapters.asami.connect :as asami-core]
+    [cz.holyjak.rad.database-adapters.asami.util :as util :refer [ensure!]]
+    [fulcro-spec.core :refer [specification assertions component behavior when-mocking => =fn=>]]
+    [com.fulcrologic.rad.ids :as ids]
+    [cz.holyjak.rad.test-schema.person :as person]
+    [cz.holyjak.rad.test-schema.address :as address]
+    [cz.holyjak.rad.test-schema.thing :as thing]
+    [com.fulcrologic.rad.attributes :as attr]
+    [cz.holyjak.rad.database-adapters.asami.write :as write]
+    [fulcro-spec.core :refer [specification assertions]]
+    [clojure.test :refer [use-fixtures]]
+    [com.fulcrologic.fulcro.algorithms.tempid :as tempid]
+    [asami.graph :as graph]))
+
+(def all-attributes (vec (concat person/attributes address/attributes thing/attributes)))
+(def key->attribute (into {}
+                          (map (fn [{::attr/keys [qualified-key] :as a}]
+                                 [qualified-key a]))
+                          all-attributes))
+
+(get key->attribute :cz.holyjak.rad.test-schema.person/things)
+(keys key->attribute)
+
+(def ^:dynamic *conn* nil)
+(def ^:dynamic *env* {})
+
+(def asami-config {:asami/driver :mem, :asami/database "test"})
+
+(defn start-connection []
+  (:production (asami/start-connections {aso/databases {:production asami-config}})))
+
+(defn reset-db []
+  (d/delete-database (asami-core/config->url asami-config)))
+
+(defn with-reset-database [tests]
+  (reset-db)
+  (tests))
+
+(defn with-env [tests]
+  (let [conn (start-connection)]
+    (binding [*conn* conn
+              *env* {::attr/key->attribute key->attribute
+                     aso/connections       {:production conn}
+                     #_#_aso/databases {:production (atom (d/db conn))}}]
+      (tests))))
+
+(use-fixtures :once with-reset-database)
+(use-fixtures :each with-env)
+
+(specification "ident->props => retractions"
+  (let [pid (random-uuid)
+        db (->> [{:id [:person/id pid]
+                  :person/email "before@email.com"}]
+                (d/transact *conn*)
+                deref
+                :db-after)
+        _   (tap> (d/q '[:find ?e ?a ?v :where [?e ?a ?v]] db)) ; FIXME rm
+        node-id (ensure! (d/q util/q-ident->node-id db [:person/id pid]) "person should exist in the db")]
+    (assertions
+      "Returns no retractions for entities that do not exist"
+      (write/clear-singular-attributes-txn db {[:no-such-thing/id 1] #{:fake/prop}}) => nil
+      "Returns no retractions if the property has no current value"
+      (write/clear-singular-attributes-txn db {[:person/id pid] #{:person/full-name}}) => nil
+      "Returns retraction of the current value"
+      (write/clear-singular-attributes-txn db {[:person/id pid] #{:person/email}})
+      => [[:db/retract node-id :person/email "before@email.com"]]
+      ; TODO fails if there are multiple values for a presumably singular attr
+      ; TODO Test with multiple props/ident and multiple idents in the input
+      )))
+
+(comment
+  (do
+    (require 'fulcro-spec.reporters.repl)
+    (fulcro-spec.reporters.repl/run-tests)))

--- a/test/cz/holyjak/rad/database_adapters/asami_basics_test.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami_basics_test.clj
@@ -7,17 +7,17 @@
 
 (def uri "asami:mem://asami-basics-test")
 
-(defn with-reset-database [tests]
+(defn reset-db []
   (d/delete-database uri)
-  (tests))
+  (swap! d/connections dissoc uri))
 
 (defn with-conn [tests]
+  (reset-db)
   (d/create-database uri)
   (let [conn (d/connect uri)]
     (binding [*conn* conn]
       (tests))))
 
-(use-fixtures :once with-reset-database)
 (use-fixtures :each with-conn)
 
 (defn db []

--- a/test/cz/holyjak/rad/database_adapters/asami_impl_spec.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami_impl_spec.clj
@@ -1,5 +1,5 @@
 (ns cz.holyjak.rad.database-adapters.asami-impl-spec
-  "Low-level, implementation-dependat tests"
+  "Low-level, implementation-dependant tests"
   (:require
     [clojure.set :as set]
     [clojure.test :refer [use-fixtures]]

--- a/test/cz/holyjak/rad/database_adapters/asami_impl_spec.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami_impl_spec.clj
@@ -68,7 +68,7 @@
                                     [:db/add ref ::address/street "111 Main"]))
         delta {[::address/id id] {::address/id id
                                   ::address/street {:before "111 Main" :after "111 Main St"}}}]
-    (let [{:keys [tempid->txid txn]} (write/delta->txn *env* :production delta)]
+    (let [{:keys [tempid->txid txn]} (write/delta->txn *env* :production delta)] ; FIXME delta->txn-with-retractions ?!
       (assertions
         "has no tempid mappings"
         (empty? tempid->txid) => true

--- a/test/cz/holyjak/rad/database_adapters/asami_spec.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami_spec.clj
@@ -402,3 +402,8 @@
 ;                                (log/spy :info person-resolver)
 ;                                (::person/transform-succeeded person-resolver)) => true
 ;                              ))))
+
+(comment
+  (do
+    (require 'fulcro-spec.reporters.repl)
+    (fulcro-spec.reporters.repl/run-tests)))

--- a/test/cz/holyjak/rad/database_adapters/asami_spec.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami_spec.clj
@@ -372,6 +372,10 @@
                                                                      ::address/street "A St"}})))))
 
 (comment
+  (do
+    (require 'fulcro-spec.reporters.repl)
+    (fulcro-spec.reporters.repl/run-tests))
+
   (def repl-conn (start-connection))
   (reset-db)
   (let [_parser (pathom/new-parser {}

--- a/test/cz/holyjak/rad/database_adapters/asami_spec.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami_spec.clj
@@ -36,13 +36,13 @@
   (:production (asami/start-connections {aso/databases {:production asami-config}})))
 
 (defn reset-db []
-  (d/delete-database (asami-core/config->url asami-config)))
+  (let [url (asami-core/config->url asami-config)]
+    (d/delete-database url)
+    (swap! d/connections dissoc url)))
 
-(defn with-reset-database [tests]
-  (reset-db)
-  (tests))
 
 (defn with-env [tests]
+  (reset-db)
   (let [conn (start-connection)]
     (binding [*conn* conn
               *env* {::attr/key->attribute key->attribute
@@ -50,7 +50,6 @@
                      #_#_aso/databases {:production (atom (d/db conn))}}]
       (tests))))
 
-(use-fixtures :once with-reset-database)
 (use-fixtures :each with-env)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/cz/holyjak/rad/database_adapters/asami_spec.clj
+++ b/test/cz/holyjak/rad/database_adapters/asami_spec.clj
@@ -371,10 +371,6 @@
                                                                      ::address/street "A St"}})))))
 
 (comment
-  (do
-    (require 'fulcro-spec.reporters.repl)
-    (fulcro-spec.reporters.repl/run-tests))
-
   (def repl-conn (start-connection))
   (reset-db)
   (let [_parser (pathom/new-parser {}


### PR DESCRIPTION
Somehow it seems that we cannot rely on the form delta to have the correct :before (though the error could also be elsewhere). I ended up with multiple values for an attribute that should be singular. With this refactoring we find out and retract the actual db value of the attribute with transacting the new one.